### PR TITLE
bench: status受信チェックの問題を修正

### DIFF
--- a/bench/src/bench/gamelog.go
+++ b/bench/src/bench/gamelog.go
@@ -127,7 +127,8 @@ func getLatestStatus(statusList []*GameStatusLog, t1 time.Time, t2 time.Time) *G
 	idx := -1
 	var t int64
 	for i, x := range statusList {
-		if t1.Before(x.ClientTime) && x.ClientTime.Before(t2) {
+		// t1 <= x.ClientTime <= t2
+		if x.ClientTime.Sub(t1) >= 0 && t2.Sub(x.ClientTime) >= 0 {
 			if idx < 0 || x.Schedule[0].Time >= t {
 				t = x.Schedule[0].Time
 				idx = i


### PR DESCRIPTION
システムのタイマーによっては連続する time.Now() が完全に同一の時刻を
返すことがある。

コマンドレスポンスの前にステータスを返しているかのチェックに受信時刻を
使っているが、同時刻を許していなかったせいで確率でバリデートエラーが
発生する。