### PR TITLE
Fix pathPrefix in bench/workermode.go

### DIFF
--- a/bench/src/bench/workermode.go
+++ b/bench/src/bench/workermode.go
@@ -26,7 +26,7 @@ var (
 	groupName  = os.Getenv("ISU7_GROUP_NAME")
 	errNoJob   = errors.New("No task:" + groupName)
 	nodeName   = "unknown"
-	pathPrefix = "inDXkQeSMCBT4usHum4ok4XhYSP0qmKe/"
+	pathPrefix = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/"
 )
 
 func updateNodeName() {


### PR DESCRIPTION
Workerモードで起動した際にベンチマーカーが動作しないため、pathPrefixを変更後のパスワードと一致するよう変更しました。